### PR TITLE
Monitor all temperature sensors

### DIFF
--- a/src/evse_monitor.cpp
+++ b/src/evse_monitor.cpp
@@ -778,11 +778,14 @@ void EvseMonitor::getTemperatureFromEvse()
         if(_temps[i].isValid())
         {
           double temp = _temps[i].get();
-          _temps[EVSE_MONITOR_TEMP_MONITOR].set(temp);
-          if(temp > _temps[EVSE_MONITOR_TEMP_MAX].get()) {
+          if(!_temps[EVSE_MONITOR_TEMP_MONITOR].isValid() || temp > _temps[EVSE_MONITOR_TEMP_MONITOR].get())
+          {
+            _temps[EVSE_MONITOR_TEMP_MONITOR].set(temp);
+          }
+          if(temp > _temps[EVSE_MONITOR_TEMP_MAX].get())
+          {
             _temps[EVSE_MONITOR_TEMP_MAX].set(temp);
           }
-          break;
         }
       }
       _data_ready.ready(EVSE_MONITOR_TEMP_DATA_READY);


### PR DESCRIPTION
Sets `_temps[EVSE_MONITOR_TEMP_MONITOR]` and `_temps[EVSE_MONITOR_TEMP_MAX]` using the temperature sensor with the highest reading, rather than always using the first sensor with a valid reading.